### PR TITLE
Change $nats::service_provider to $nats::service_type #20

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,3 +7,4 @@ fixtures:
     collectd: "https://github.com/voxpupuli/puppet-collectd.git"
     yum: "https://github.com/voxpupuli/puppet-yum.git"
     concat: "https://github.com/puppetlabs/puppetlabs-concat"
+    epel: "https://github.com/stahnma/puppet-module-epel"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,6 +2,6 @@ class nats::service {
   service { $nats::service_name:
     ensure   => $nats::service_ensure,
     enable   => true,
-    provider => $nats::service_provider,
+    provider => $nats::service_type,
   }
 }


### PR DESCRIPTION
Commit a change that should fix and issue where tests run on
modules/profiles using choria-nats would fail a `is_expected.to compile`
test due to an unknown variable error.