### PR TITLE
(#37) Quote password to avoid parse errors.

### DIFF
--- a/templates/nats.cfg.epp
+++ b/templates/nats.cfg.epp
@@ -27,7 +27,7 @@ cluster {
 
   authorization {
     user: routes
-    password: <%= $nats::routes_password %>
+    password: "<%= $nats::routes_password %>"
     timeout: 0.75
   }
 


### PR DESCRIPTION
- password in authorization section is quoted by default