### PR TITLE
(#38) Use notify to avoid issues during installs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,8 @@ class nats (
       include nats::collectd
     }
   } else {
-    fail(sprintf("%s is not in the list of NATS servers %s", $facts["networking"]["fqdn"], $servers.join(", ")))
+    notify{'Nats sanity check':
+      message => sprintf("%s is not in the list of NATS servers %s", $facts["networking"]["fqdn"], $servers.join(", "))
+    }
   }
 }


### PR DESCRIPTION
- Use a notify instead of fail, to avoid issues with the first puppet run on freshly installed systems