### PR TITLE
(#40) Remove deprecation warning messages

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,16 +1,16 @@
 ---
-version: 4
-datadir: data
-hierarchy:
-  - name: 'Major version'
-    backend: yaml
-    path: "%{facts.os.name}-%{facts.os.release.major}"
-  - name: 'Distribution name'
-    backend: yaml
-    path: "%{facts.os.name}"
-  - name: 'OS family'
-    backend: yaml
-    path: "%{facts.os.family}"
-  - name: common
-    backend: yaml
+version: 5
 
+defaults:
+  datadir: "data"
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Major version"
+    path: "%{facts.os.name}-%{facts.os.release.major}.yaml"
+  - name: "Distribution name"
+    path: "%{facts.os.name}.yaml"
+  - name: "OS family"
+    path: "%{facts.os.family}.yaml"
+  - name: "common"
+    path: "common.yaml"

--- a/metadata.json
+++ b/metadata.json
@@ -14,10 +14,9 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.5.0"
+      "version_requirement": ">= 4.9.0"
     }
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
This commit:
  - bumps required puppet version to 4.9 (required by other changes)
  - updates hiera.yaml syntax to version 5
  - removes deprecated data_provider option from metadata.json