### PR TITLE
Add listen_address to nats service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It only supports verified TLS connections and defaults to using the Puppet certi
 It's recommended that you define a cluster of servers equal to 3 nodes, but it can run
 standalone too.
 
-By default clients will use port `4222`, monitoring will be on port `8222` and
+By default clients will listen on `::`, use port `4222`, monitoring will be on port `8222` and
 cluster comms will use port `4223`.
 
 This module installs the included `gnatsd` binary to `/usr/sbin/gnatsd` by

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class nats (
   String $client_port = "4222",
   String $monitor_port = "8222",
   String $cluster_port = "4223",
+  String $listen_address = "::",
   Integer $max_payload_size = 1048576,
   Integer $max_pending_size = 10485760,
   Integer $max_connections = 65536,

--- a/templates/nats.cfg.epp
+++ b/templates/nats.cfg.epp
@@ -1,3 +1,4 @@
+net: <%= $nats::listen_address %>
 port: <%= $nats::client_port %>
 monitor_port: <%= $nats::monitor_port %>
 


### PR DESCRIPTION
Sets up `net:` configuration directive and sets it to `"::"`. Note: the
current default behavior seems that nats is listening on `0.0.0.0`.

Since this module supports only Linux and `net.ipv6.bindv6only=0` is the
default on all of these, `:: `is the expected behaviour as more SRV
records will resolve A and AAAA records these days.