### PR TITLE
(#57) Don't include class systemd in install/systemd.pp

### DIFF
--- a/manifests/install/systemd.pp
+++ b/manifests/install/systemd.pp
@@ -1,6 +1,5 @@
 # Manage systemd unit
 class nats::install::systemd {
-  contain "::systemd"
 
   systemd::unit_file { "${nats::service_name}.service":
     content => epp("nats/systemd_service.epp"),


### PR DESCRIPTION
The `systemd` class is already included by `systemd::unit_file` so it is unnecessary here.

This also prevents unwanted restarts of the `gnatsd` service that happen when other classes use defined types from the systemd module, for example when managing a drop-in file using `systemd::dropin_file` (from camptocamp/systemd 1.0.0). Such defined types trigger `Exec[systemctl-daemon-reload]` which propagates through to the `nats::install::systemd` class which notifies the `nats::service` class. Not including the `systemd` class here fixes that.

Example output of a Puppet agent run that triggered an unnecessary restart of gnatsd:

```
Notice: /Stage[main]/Profile::Foreman_proxy/Systemd::Dropin_file[10-foreman-proxy-etc-environment.conf]/File[/etc/systemd/system/foreman-proxy.service.d/10-foreman-proxy-etc-environment.conf]/ensure: defined content as '{md5}6373a720c0c8c8008f3e0055a42f82d7'
Info: /Stage[main]/Profile::Foreman_proxy/Systemd::Dropin_file[10-foreman-proxy-etc-environment.conf]/File[/etc/systemd/system/foreman-proxy.service.d/10-foreman-proxy-etc-environment.conf]: Scheduling refresh of Class[Systemd::Systemctl::Daemon_reload]
Info: Systemd::Dropin_file[10-foreman-proxy-etc-environment.conf]: Scheduling refresh of Service[foreman-proxy]
Info: Class[Systemd::Systemctl::Daemon_reload]: Scheduling refresh of Exec[systemctl-daemon-reload]
Notice: /Stage[main]/Systemd::Systemctl::Daemon_reload/Exec[systemctl-daemon-reload]: Triggered 'refresh' from 1 event
Info: Class[Nats::Install::Systemd]: Scheduling refresh of Class[Nats::Service]
Info: Class[Nats::Install]: Scheduling refresh of Class[Nats::Service]
Info: Class[Nats::Service]: Scheduling refresh of Service[gnatsd]
Notice: /Stage[main]/Nats::Service/Service[gnatsd]: Triggered 'refresh' from 1 event
```