### PR TITLE
(#59) Bump supported version of camptocamp/systemd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/choria-io/puppet-nats/issues",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" },
-    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" }
+    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 2.0.0" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Closes #59 

BTW, I'm not 100% sure if `2.0.0` is a best version.