### PR TITLE
Support for debian Stretch

### DIFF
--- a/data/Debian-9.yaml
+++ b/data/Debian-9.yaml
@@ -1,0 +1,2 @@
+---
+nats::service_type: systemd


### PR DESCRIPTION
A silly pull request to avoid the use of init provider in a unknown Stretch distro for the puppet module